### PR TITLE
set overwrite: false in importer

### DIFF
--- a/lib/count-import.js
+++ b/lib/count-import.js
@@ -18,6 +18,7 @@ module.exports = function (archive, dir, opts, cb) {
   })
 
   importer = hyperImport(archive, dir, {
+    overwrite: false, // tmp workaround until watching is stable - NEVER overwrite existing files
     live: opts.live,
     resume: opts.resume,
     ignore: opts.ignore


### PR DESCRIPTION
fixes a bunch of weird cli issues related to files being added over and over again. depends on https://github.com/juliangruber/hyperdrive-import-files/pull/25
