### PR TITLE
Catch LevelDB OpenErrors

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,7 +72,7 @@ Dat.prototype._open = function (cb) {
   if (this._closed) return cb('Cannot open a closed Dat')
   var self = this
   getDb(self, function (err) {
-    if (err) return self._emitError(err)
+    if (err) return cb(err)
     var drive = hyperdrive(self.db)
     self.archive = drive.createArchive(self.key, {
       live: self.live,

--- a/lib/db.js
+++ b/lib/db.js
@@ -1,14 +1,19 @@
 var fs = require('fs')
 var encoding = require('dat-encoding')
+var level = require('level')
 
 module.exports = function getDb (dat, cb) {
   if (!dat.db) {
     try {
       fs.accessSync(dat._datPath, fs.F_OK)
     } catch (e) { fs.mkdirSync(dat._datPath) }
-    dat.db = require('level')(dat._datPath)
+    dat.db = level(dat._datPath, function (err) {
+      if (err) return cb(err)
+      tryResume()
+    })
+  } else {
+    tryResume()
   }
-  tryResume()
 
   function tryResume () {
     var db = dat.db

--- a/tests/misc.js
+++ b/tests/misc.js
@@ -124,3 +124,21 @@ test('swarm options 3.2.x compat', function (t) {
     dat._joinSwarm()
   })
 })
+
+test('leveldb open error', function (t) {
+  var a = Dat({ dir: process.cwd() })
+  var b = Dat({ dir: process.cwd() })
+  a.open(function (err) {
+    t.error(err)
+    b.open(function (err) {
+      t.ok(err)
+      a.close(function () {
+        a.db.close(function () {
+          rimraf(path.join(process.cwd(), '.dat'), function () {
+            t.end()
+          })
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
This is fix part one for https://github.com/datproject/dat/issues/561, next we just need to print a nice error message if `/^OpenError/.test(err.message)`.