### PR TITLE
Clarify error for existing dat in directory

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -3,8 +3,7 @@ var encoding = require('dat-encoding')
 var level = require('level')
 
 module.exports = function getDb (dat, cb) {
-  var EXISTS_ERROR = 'Error: Destination path already exists and contains a different dat. \
-    \nPlease download to a new directory or remove the existing .dat folder.'
+  var EXISTS_ERROR = 'Error: Destination path already exists and contains a different dat. \nPlease download to a new directory or remove the existing .dat folder.'
 
   if (!dat.db) {
     try {

--- a/lib/db.js
+++ b/lib/db.js
@@ -3,6 +3,9 @@ var encoding = require('dat-encoding')
 var level = require('level')
 
 module.exports = function getDb (dat, cb) {
+  var EXISTS_ERROR = 'Error: Destination path already exists and contains a different dat. \
+    \nPlease download to a new directory or remove the existing .dat folder.'
+
   if (!dat.db) {
     try {
       fs.accessSync(dat._datPath, fs.F_OK)
@@ -25,7 +28,7 @@ module.exports = function getDb (dat, cb) {
         ? typeof dat.key === 'string'
           ? dat.key : dat.key.toString('hex')
         : null
-      if (key && key !== value) return cb('Another Dat was already downloaded here.')
+      if (key && key !== value) return cb(EXISTS_ERROR)
 
       value = encoding.decode(value)
       dat.key = value


### PR DESCRIPTION
New error if user tries to download to a directory that has a different Dat:

```
Error: Destination path already exists and contains a different dat.
Please download to a new directory or remove the existing .dat folder.
```